### PR TITLE
Update JSM estimator defaults and Data Migration CS2 score

### DIFF
--- a/jsm-estimator.html
+++ b/jsm-estimator.html
@@ -37,7 +37,7 @@
                     <tr data-phase-key="discovery" class="custom-hours-row">
                         <td>Initiation & Discovery</td>
                         <td colspan="4" class="custom-hours-cell">
-                            <input type="number" id="discovery-hours-input" value="0" min="0" class="custom-phase-hours-input"> Hours
+                            <input type="number" id="discovery-hours-input" value="60" min="0" class="custom-phase-hours-input"> Hours
                         </td>
                     </tr>
 
@@ -83,7 +83,7 @@
                         <td class="selectable-cell" data-value="cs2">Team needs to track multiple types of assets and config items, potentially including software or services. Requires structured data import from a few sources and meaningful integration with ITSM processes. Involves moderate schema configuration and some automation.</td>
                         <td class="selectable-cell" data-value="cs3">Team requires a comprehensive CMDB/Asset Management solution tracking diverse CIs (IT, potentially non-IT) with intricate relationships and dependencies. Demands automated data population from multiple disparate sources, advanced automation, and complex reporting. Requires significant schema design and configuration effort.</td>
                     </tr>
-                     <tr data-phase-key="data-migration" data-phase="Data Migration" data-hours='{"na": 0, "cs1": 30, "cs2": 45, "cs3": 100}'>
+                     <tr data-phase-key="data-migration" data-phase="Data Migration" data-hours='{"na": 0, "cs1": 30, "cs2": 60, "cs3": 100}'>
                          <td>Data Migration</td>
                         <td class="selectable-cell" data-value="na">N/A</td>
                         <td class="selectable-cell" data-value="cs1">Basic data import, likely focused on getting current or essential data into the new system.</td>
@@ -101,7 +101,7 @@
                     <tr data-phase-key="production-release" class="custom-hours-row">
                         <td>Production Release</td>
                          <td colspan="4" class="custom-hours-cell">
-                            <input type="number" id="release-hours-input" value="0" min="0" class="custom-phase-hours-input"> Hours
+                            <input type="number" id="release-hours-input" value="40" min="0" class="custom-phase-hours-input"> Hours
                          </td>
                     </tr>
                     <tr data-phase-key="warranty" class="custom-hours-row">

--- a/script.js
+++ b/script.js
@@ -40,7 +40,21 @@ document.addEventListener('DOMContentLoaded', () => {
                 // Ensure all teams have customPhaseHours initialized
                 Object.values(teamsData).forEach(team => {
                     if (!team.customPhaseHours) {
-                        team.customPhaseHours = { 'discovery': 0, 'production-release': 0, 'warranty': 0 };
+                        // Initialize with new defaults if customPhaseHours object doesn't exist
+                        team.customPhaseHours = { 'discovery': 60, 'production-release': 40, 'warranty': 0 };
+                    } else {
+                        // If customPhaseHours exists, check and apply new defaults if specific phases are 0 or undefined
+                        // This handles data from older versions where the default might have been 0
+                        if (team.customPhaseHours['discovery'] === undefined || team.customPhaseHours['discovery'] === 0) {
+                            team.customPhaseHours['discovery'] = 60;
+                        }
+                        if (team.customPhaseHours['production-release'] === undefined || team.customPhaseHours['production-release'] === 0) {
+                            team.customPhaseHours['production-release'] = 40;
+                        }
+                        // Ensure warranty has a default if not set, but don't override if it was explicitly set to something else (even 0)
+                        if (team.customPhaseHours['warranty'] === undefined) {
+                            team.customPhaseHours['warranty'] = 0;
+                        }
                     }
                 });
             } catch (e) {
@@ -82,8 +96,8 @@ document.addEventListener('DOMContentLoaded', () => {
             teamsData[teamName] = {
                 selections: {},
                 customPhaseHours: {
-                    'discovery': parseInt(discoveryHoursInput.value, 10) || 0, // Or just 0
-                    'production-release': parseInt(releaseHoursInput.value, 10) || 0,
+                    'discovery': parseInt(discoveryHoursInput.value, 10) || 60,
+                    'production-release': parseInt(releaseHoursInput.value, 10) || 40,
                     'warranty': parseInt(warrantyHoursInput.value, 10) || 0
                 },
                 miscHours: 0,
@@ -183,9 +197,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- Reset form to default state (e.g., when no team is selected or all data cleared) ---
     function resetFormToDefaults() {
         clearSelectionsVisually();
-        discoveryHoursInput.value = 0;
-        releaseHoursInput.value = 0;
-        warrantyHoursInput.value = 0;
+        discoveryHoursInput.value = 60; // Default to 60
+        releaseHoursInput.value = 40; // Default to 40
+        warrantyHoursInput.value = 0; // Default to 0 (or specific value if required)
         miscHoursInput.value = 0;
         teamNameInput.value = '';
         // totalHoursDisplay will be updated by calculateTotalHours


### PR DESCRIPTION
- Set Initiation & Discovery phase to default to 60 hours.
- Set Production Release phase to default to 40 hours.
- Changed Data Migration CS2 score to 60 hours.
- Updated JavaScript logic to reflect these new defaults for new and existing team data.