### PR TITLE
Add 'Integrations' row to JSM estimator

### DIFF
--- a/jsm-estimator.html
+++ b/jsm-estimator.html
@@ -83,6 +83,13 @@
                         <td class="selectable-cell" data-value="cs2">Team needs to track multiple types of assets and config items, potentially including software or services. Requires structured data import from a few sources and meaningful integration with ITSM processes. Involves moderate schema configuration and some automation.</td>
                         <td class="selectable-cell" data-value="cs3">Team requires a comprehensive CMDB/Asset Management solution tracking diverse CIs (IT, potentially non-IT) with intricate relationships and dependencies. Demands automated data population from multiple disparate sources, advanced automation, and complex reporting. Requires significant schema design and configuration effort.</td>
                     </tr>
+                    <tr data-phase-key="integrations" data-phase="Integrations" data-hours='{"na": 0, "cs1": 50, "cs2": 80, "cs3": 100}'>
+                        <td>Integrations</td>
+                        <td class="selectable-cell" data-value="na">N/A</td>
+                        <td class="selectable-cell" data-value="cs1">Basic integration requirements, minimal complexity.</td>
+                        <td class="selectable-cell" data-value="cs2">Moderate integration complexity, multiple systems.</td>
+                        <td class="selectable-cell" data-value="cs3">High integration complexity, custom solutions needed.</td>
+                    </tr>
                      <tr data-phase-key="data-migration" data-phase="Data Migration" data-hours='{"na": 0, "cs1": 30, "cs2": 60, "cs3": 100}'>
                          <td>Data Migration</td>
                         <td class="selectable-cell" data-value="na">N/A</td>


### PR DESCRIPTION
This commit introduces a new row for 'Integrations' in the Jira Service Management estimator.

The row includes complexity scores CS1=50 hours, CS2=80 hours, and CS3=100 hours, and functions like other rows in the estimator.

The changes were made in `jsm-estimator.html`. The existing JavaScript handles the new row dynamically without requiring modifications.